### PR TITLE
Simplify tox passenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ max-line-length = 120
 filename = ./parsita/*
 
 [testenv]
-passenv = CI TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_REQUEST TRAVIS_JOB_ID TRAVIS_REPO_SLUG TRAVIS_COMMIT
+passenv = CI TRAVIS TRAVIS_*
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt


### PR DESCRIPTION
From recommendation here: https://github.com/codecov/example-python#testing-with-tox