### PR TITLE
Add a predicate parser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -229,6 +229,33 @@ A repeated separated parser matches ``parser`` separated by ``separator``, retur
         my_list = '[' >> repsep(integer, ',') << ']'
     assert ListParsers.my_list.parse('[1,2,3]') == Success([1, 2, 3])
 
+``pred(parser, predicate, description)``: predicate parser
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A predicate parser matches ``parser`` and, if it succeeds, runs a test function ``predicate`` on the return value. If ``predicate`` returns ``True``, the predicate parser succeeds, returning the same value; if it returns ``False``, the parser fails with the message that it is expecting ``description``.
+
+.. code:: python
+
+    class IntervalParsers(TextParsers):
+        number = reg('\d+') > int
+        pair = '[' >> number << ',' & number << ']'
+        interval = pred(pair, lambda x: x[0] <= x[1], 'ordered pair')
+    assert IntervalParsers.interval.parse('[1, 2]') == Success([1, 2])
+    assert IntervalParsers.interval.parse('[2, 1]') != Success([2, 1])
+
+``any1``: any one element
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A parser that matches any single input element. This is not a particularly useful parser in the context of parsing text (for which ``reg(r'.')`` would be more standard). But in the ``GeneralParsers`` context, this is useful as the first argument to ``pred`` when one merely wants to run the predicate on a single token. This parser can only fail at the end of the stream. Note that ``any1`` is not a function—it is a complete parser itself.
+
+.. code:: python
+
+    class DigitParsers(GeneralParsers):
+        digit = pred(any1, lambda x: x['type'] == 'digit', 'a digit') > \
+            (lambda x: x['payload'])
+    assert DigitParsers.digit.parse([{'type': 'digit', 'payload': 3}]) == \
+        Success(3)
+
 ``eof``: end of file
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/src/parsita/__init__.py
+++ b/src/parsita/__init__.py
@@ -1,3 +1,3 @@
 from .state import Reader, SequenceReader, StringReader, Result, Success, Failure, ParseError  # noqa: F401
-from .parsers import Parser, lit, reg, opt, rep, rep1, repsep, rep1sep, eof, success, failure, pred  # noqa: F401
+from .parsers import Parser, lit, reg, opt, rep, rep1, repsep, rep1sep, eof, success, failure, pred, any1  # noqa: F401
 from .metaclasses import GeneralParsers, TextParsers, fwd  # noqa: F401

--- a/src/parsita/__init__.py
+++ b/src/parsita/__init__.py
@@ -1,3 +1,3 @@
 from .state import Reader, SequenceReader, StringReader, Result, Success, Failure, ParseError  # noqa: F401
-from .parsers import Parser, lit, reg, opt, rep, rep1, repsep, rep1sep, eof, success, failure  # noqa: F401
+from .parsers import Parser, lit, reg, opt, rep, rep1, repsep, rep1sep, eof, success, failure, pred  # noqa: F401
 from .metaclasses import GeneralParsers, TextParsers, fwd  # noqa: F401

--- a/src/parsita/parsers.py
+++ b/src/parsita/parsers.py
@@ -265,9 +265,12 @@ class PredicateParser(Generic[Input, Output], Parser[Input, Input]):
         remainder = reader
         status = self.parser.consume(remainder)
         if isinstance(status, Continue):
-            if not self.predicate(status.value):
+            if self.predicate(status.value):
+                return status
+            else:
                 return Backtrack(remainder, lambda: self.description)
-        return status
+        else:
+            return status
 
     def __repr__(self):
         return self.name_or_nothing() + 'pred({}, {})'.format(repr(self.parser), self.description)

--- a/src/parsita/parsers.py
+++ b/src/parsita/parsers.py
@@ -254,45 +254,41 @@ def lit(literal: Sequence[Input], *literals: Sequence[Sequence[Input]]) -> Parse
         return options.handle_literal(literal)
 
 
-class PredicateParser(Generic[Input], Parser[Input, Input]):
-    def __init__(self, predicate: Callable[[Input], bool],
-            predicate_descr: str):
+class PredicateParser(Generic[Input, Output], Parser[Input, Input]):
+    def __init__(self, parser: Parser[Input, Output],
+                 predicate: Callable[[Output], bool],
+                 predicate_descr: str):
         super().__init__()
+        self.parser = parser
         self.predicate = predicate
         self.predicate_descr = predicate_descr
 
     def consume(self, reader: Reader[Input]):
         remainder = reader
-        if remainder.finished:
-            return Backtrack(remainder, lambda: self.predicate_descr)
-        remainder_first = remainder.first
-        if self.predicate(remainder_first):
-            remainder = remainder.rest
-        else:
-            return Backtrack(remainder, lambda: self.predicate_descr)
-
-        return Continue(remainder, remainder_first)
+        status = self.parser.consume(remainder)
+        if isinstance(status, Continue):
+            if not self.predicate(status.value):
+                return Backtrack(remainder, lambda: self.predicate_descr)
+        return status
 
     def __repr__(self):
         return self.name_or_nothing() + self.predicate_descr
 
 
-def pred(predicate: Callable[[Input], bool], predicate_descr: str) -> Parser:
-    """Match an element if it satisfies the predicate.
-
-    In the ``TextParsers`` context, this would accept only a single character.
-    It's better to use ``reg`` in that case, if possible.
-    This parser is more useful in the ``GeneralContext``, allowing e. g.
-    matching by token type but ignoring source information in the token.
+def pred(parser: Parser[Input, Output],
+         predicate: Callable[[Output], bool],
+         predicate_descr: str) -> PredicateParser[Input, Output]:
+    """Match ``parser``'s result if it satisfies the predicate.
 
     Args:
-        predicate: A predicate to satisfy
+        parser: Provides the result
+        predicate: A predicate for the result to satisfy
         predicate_descr: Name for the predicate, to use in error reporting
 
     Returns:
         A ``PredicateParser``.
     """
-    return PredicateParser(predicate, predicate_descr)
+    return PredicateParser(parser, predicate, predicate_descr)
 
 
 class RegexParser(Parser[str, str]):
@@ -744,9 +740,30 @@ def failure(expected: str = ''):
     return FailureParser(expected)
 
 
+class AnyParser(Generic[Input], Parser[Input, Input]):
+    """Matches any single element in the input.
+
+       This is useful with ``pred``. Also note this parser will fail on end of stream.
+    """
+    def __init__(self):
+        super().__init__()
+
+    def consume(self, reader: Reader[Input]) -> Status[Input, None]:
+        if reader.finished:
+            return Backtrack(reader, lambda: 'any')
+        else:
+            return Continue(reader.rest, reader.first)
+
+    def __repr__(self):
+        return self.name_or_nothing() + 'any1'
+
+
+any1 = AnyParser()
+
+
 __all__ = ['Parser', 'LiteralParser', 'LiteralStringParser', 'lit', 'RegexParser', 'reg', 'OptionalParser', 'opt',
            'AlternativeParser', 'SequentialParser', 'DiscardLeftParser', 'DiscardRightParser', 'RepeatedOnceParser',
            'rep1', 'RepeatedParser', 'rep', 'RepeatedOnceSeparatedParser', 'rep1sep', 'RepeatedSeparatedParser',
            'repsep', 'ConversionParser', 'EndOfSourceParser', 'eof', 'SuccessParser', 'success', 'FailureParser',
            'failure', 'completely_parse_reader',
-           'PredicateParser', 'pred']
+           'PredicateParser', 'pred', 'any1']

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -37,8 +37,8 @@ class LiteralTestCase(TestCase):
 class PredicateTestCase(TestCase):
     def test_predicate(self):
         class TestParsers(GeneralParsers):
-            a = pred(lambda x: x in ('A', 'a'), 'letter A')
-            d = pred(str.isdigit, 'digit')
+            a = pred(any1, lambda x: x in ('A', 'a'), 'letter A')
+            d = pred(any1, str.isdigit, 'digit')
 
         self.assertEqual(TestParsers.a.parse('a'), Success('a'))
         self.assertEqual(TestParsers.a.parse('A'), Success('A'))
@@ -403,6 +403,16 @@ class SuccessFailureTestCase(TestCase):
         self.assertEqual(TestParsers.bbb.parse('aabb'), Failure('Expected something else but found b at index 2'))
         self.assertEqual(str(TestParsers.aaa), "aaa = rep('a') & success(1) & rep('b')")
         self.assertEqual(str(TestParsers.bbb), "bbb = 'aa' & failure('something else') & 'bb'")
+
+
+class AnyTestCase(TestCase):
+    def test_any(self):
+        class TestParsers(GeneralParsers):
+            any2 = any1 & any1
+
+        self.assertEqual(TestParsers.any2.parse('ab'), Success(['a', 'b']))
+        self.assertEqual(TestParsers.any2.parse('a'), Failure('Expected any but found end of source'))
+        self.assertEqual(str(TestParsers.any2), "any2 = any1 & any1")
 
 
 class OptionsResetTest(TestCase):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -45,7 +45,7 @@ class PredicateTestCase(TestCase):
         self.assertEqual(TestParsers.d.parse('2'), Success('2'))
         self.assertEqual(TestParsers.d.parse('23'), Failure('Expected end of source but found 3 at index 1'))
         self.assertEqual(TestParsers.d.parse('a'), Failure('Expected digit but found a at index 0'))
-        self.assertEqual(str(TestParsers.a), "a = letter A")
+        self.assertEqual(str(TestParsers.a), "a = pred(any1, letter A)")
 
 
 class ForwardDeclarationTestCase(TestCase):
@@ -411,7 +411,7 @@ class AnyTestCase(TestCase):
             any2 = any1 & any1
 
         self.assertEqual(TestParsers.any2.parse('ab'), Success(['a', 'b']))
-        self.assertEqual(TestParsers.any2.parse('a'), Failure('Expected any but found end of source'))
+        self.assertEqual(TestParsers.any2.parse('a'), Failure('Expected anything but found end of source'))
         self.assertEqual(str(TestParsers.any2), "any2 = any1 & any1")
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -34,6 +34,20 @@ class LiteralTestCase(TestCase):
         self.assertRaisesRegex(ParseError, 'Expected b but found a at index 0', TestParsers.bb.parse('aa').or_die)
 
 
+class PredicateTestCase(TestCase):
+    def test_predicate(self):
+        class TestParsers(GeneralParsers):
+            a = pred(lambda x: x in ('A', 'a'), 'letter A')
+            d = pred(str.isdigit, 'digit')
+
+        self.assertEqual(TestParsers.a.parse('a'), Success('a'))
+        self.assertEqual(TestParsers.a.parse('A'), Success('A'))
+        self.assertEqual(TestParsers.d.parse('2'), Success('2'))
+        self.assertEqual(TestParsers.d.parse('23'), Failure('Expected end of source but found 3 at index 1'))
+        self.assertEqual(TestParsers.d.parse('a'), Failure('Expected digit but found a at index 0'))
+        self.assertEqual(str(TestParsers.a), "a = letter A")
+
+
 class ForwardDeclarationTestCase(TestCase):
     def test_forward_declaration(self):
         class TestParsers(GeneralParsers):

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -32,12 +32,13 @@ class LiteralTestCase(TestCase):
 class PredicateTestCase(TestCase):
     def test_interval(self):
         class TestParsers(TextParsers):
-            number = reg('\d+') > int
+            number = reg(r'\d+') > int
             pair = '[' >> number << ',' & number << ']'
             interval = pred(pair, lambda x: x[0] <= x[1], 'ordered pair')
 
         self.assertEqual(TestParsers.interval.parse('[1, 2]'), Success([1, 2]))
         self.assertIsInstance(TestParsers.interval.parse('[2, 1]'), Failure)
+        self.assertEqual(TestParsers.pair.parse('[1,a]'), TestParsers.interval.parse('[1,a]'))
 
 
 class RegexTestCase(TestCase):

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -29,6 +29,17 @@ class LiteralTestCase(TestCase):
         self.assertEqual(str(TestParsers.hundred), "hundred = '100'")
 
 
+class PredicateTestCase(TestCase):
+    def test_interval(self):
+        class TestParsers(TextParsers):
+            number = reg('\d+') > int
+            pair = '[' >> number << ',' & number << ']'
+            interval = pred(pair, lambda x: x[0] <= x[1], 'ordered pair')
+
+        self.assertEqual(TestParsers.interval.parse('[1, 2]'), Success([1, 2]))
+        self.assertIsInstance(TestParsers.interval.parse('[2, 1]'), Failure)
+
+
 class RegexTestCase(TestCase):
     def test_regex(self):
         class TestParsers(TextParsers):


### PR DESCRIPTION
This one adds a predicate parser, which is useful to match a general input literal partially, like matching a token by its type but not all other info which a token has.

Simple tests are included (I used the literal parser test case as a reference), and are passing.

What do you think? :slightly_smiling_face: 