### PR TITLE
Several small fixes:

### DIFF
--- a/src/parsita/options.py
+++ b/src/parsita/options.py
@@ -17,7 +17,7 @@ def default_handle_literal(literal: Any):
 
 def wrap_literal(literal: Input):
     from .parsers import LiteralParser
-    return LiteralParser(literal)
+    return LiteralParser((literal,))
 
 
 handle_literal = default_handle_literal

--- a/src/parsita/options.py
+++ b/src/parsita/options.py
@@ -15,9 +15,9 @@ def default_handle_literal(literal: Any):
     return LiteralStringParser(literal, whitespace)
 
 
-def wrap_literal(literal: Input):
+def wrap_literal(literal: Sequence[Input]):
     from .parsers import LiteralParser
-    return LiteralParser((literal,))
+    return LiteralParser(literal)
 
 
 handle_literal = default_handle_literal

--- a/src/parsita/state.py
+++ b/src/parsita/state.py
@@ -20,6 +20,7 @@ class Reader(Generic[Input]):
         finished (bool): Indicates if the source is at the end. It is an error
             to access ``first`` or ``rest`` if ``finished`` is ``True``.
     """
+
     first = NotImplemented  # type: Input
     rest = NotImplemented  # type: Reader[Input]
     position = NotImplemented  # type: int
@@ -75,7 +76,7 @@ class Reader(Generic[Input]):
             return 'Reader({}@{})'.format(self.first, self.position)
 
 
-class SequenceReader(Reader):
+class SequenceReader(Reader[Input]):
     """A reader for sequences that should not be sliced.
 
     Python makes a copy when a sequence is sliced. This reader avoids making
@@ -126,20 +127,21 @@ class StringReader(Reader[str]):
         return self.source[self.position]
 
     @property
-    def rest(self) -> 'StringReader[str]':
+    def rest(self) -> 'StringReader':
         return StringReader(self.source, self.position + 1)
 
     @property
     def finished(self) -> bool:
         return self.position >= len(self.source)
 
-    def drop(self, count: int) -> 'StringReader[Input]':
+    def drop(self, count: int) -> 'StringReader':
         return StringReader(self.source, self.position + count)
 
     next_token_regex = re.compile(r'[\(\)\[\]\{\}\"\']|\w+|[^\w\s\(\)\[\]\{\}\"\']+|\s+')
 
     def next_token(self) -> str:
         match = self.next_token_regex.match(self.source, self.position)
+        assert match is not None
         return self.source[match.start():match.end()]
 
     def current_line(self):
@@ -293,7 +295,7 @@ class ParseError(Exception):
 
 class Status(Generic[Input, Output]):
     farthest = None  # type: Optional[Reader]
-    expected = ()  # type: Tuple[Callable[[], str]]
+    expected = ()  # type: Tuple[Callable[[], str], ...]
 
     def merge(self, status: 'Status[Input, Output]') -> 'Status[Input, Output]':
         """Merge the failure message from another status into this one.

--- a/src/parsita/state.py
+++ b/src/parsita/state.py
@@ -142,7 +142,7 @@ class StringReader(Reader[str]):
     def next_token(self) -> str:
         match = self.next_token_regex.match(self.source, self.position)
         if match is None:
-            return self.source[match.start]
+            return self.source[self.position]
         else:
             return self.source[match.start():match.end()]
 

--- a/src/parsita/state.py
+++ b/src/parsita/state.py
@@ -141,8 +141,10 @@ class StringReader(Reader[str]):
 
     def next_token(self) -> str:
         match = self.next_token_regex.match(self.source, self.position)
-        assert match is not None
-        return self.source[match.start():match.end()]
+        if match is None:
+            return self.source[match.start]
+        else:
+            return self.source[match.start():match.end()]
 
     def current_line(self):
         characters_consumed = 0

--- a/src/parsita/util.py
+++ b/src/parsita/util.py
@@ -1,6 +1,6 @@
 from typing import Callable, TypeVar, Iterable
 
-A = TypeVar('Input')
+A = TypeVar('A')
 
 
 def constant(x: A) -> Callable[..., A]:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,3 +1,4 @@
+import re
 from unittest import TestCase
 
 from parsita import *
@@ -50,3 +51,15 @@ class StateTestCase(TestCase):
         # line. Here, the position has been artificially advanced beyond the length of the input.
         reader = StringReader('foo', 3)
         self.assertEqual(reader.current_line(), None)
+
+    def test_reader_with_defective_next_token_regex(self):
+        # With the default value of next_token_regex, a match cannot fail. However, if a fallible regex is provided to
+        # a super class next_token should not crash.
+        class DefectiveReader(StringReader):
+            next_token_regex = re.compile(r'[A-Za-z0-9]+')
+
+        good_position = DefectiveReader('foo_foo', 4)
+        self.assertEqual(good_position.next_token(), 'foo')
+
+        bad_position = DefectiveReader('foo_foo', 3)
+        self.assertEqual(bad_position.next_token(), '_')


### PR DESCRIPTION
While I’m going to expand that other pull request tomorrow, I’ve already compiled here some fixes (or misunderstandings :grin:), if you’d like. (At first I tried to make mypy happy, but that doesn’t seem reasonable at the moment.) I’ll be glad to leave only those you consider correct.

options.py:
* `wrap_literal`: `LiteralParser` expected a sequence of Inputs

parsers.py:
* `*parsers` arguments’ types now conform with PEP 484 <https://www.python.org/dev/peps/pep-0484/#arbitrary-argument-lists-and-default-argument-values>
* minor fixes (if I’m not wrong)

state.py:
* an assertion in using a regex match, in case it would be None for some reason
* minor fixes in several type hints

util.py:
* PEP 484 advices the first `TypeVar` argument be the same as the var name. That probably was a typo