### PR TITLE
Convert ParseError to a dataclass with state

### DIFF
--- a/src/parsita/parsers.py
+++ b/src/parsita/parsers.py
@@ -239,7 +239,7 @@ def completely_parse_reader(parser: Parser[Input, Output], reader: Reader[Input]
                 used.add(expected)
                 unique_expected.append(expected)
 
-        return Failure(ParseError(state.farthest.expected_error(unique_expected)))
+        return Failure(ParseError(state.farthest, unique_expected))
 
 
 class LiteralParser(Generic[Input], Parser[Input, Input]):

--- a/src/parsita/state.py
+++ b/src/parsita/state.py
@@ -247,28 +247,18 @@ class Continue(Generic[Input, Output]):
     value: Output
 
 
+@dataclass(frozen=True)
 class ParseError(Exception):
     """Parsing failure.
 
     The container for the error of failed parsing.
-
-    Attributes:
-        message (str): A human-readable error message
     """
 
-    def __init__(self, message: str):
-        self.message = message
-
-    def __eq__(self, other):
-        if isinstance(other, ParseError):
-            return self.message == other.message
-        return NotImplemented
+    farthest: Reader[Any]
+    expected: List[str]
 
     def __str__(self):
-        return self.message
-
-    def __repr__(self):
-        return f"ParseError({self.message!r})"
+        return self.farthest.expected_error(self.expected)
 
 
 @dataclass(frozen=True)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -18,16 +18,25 @@ def test_state_creation():
     cont = Continue(read, 40)
     assert cont.value == 40
 
-    error = ParseError("Expected a but found b at index 0")
-    assert str(error) == "Expected a but found b at index 0"
-    assert repr(error) == "ParseError('Expected a but found b at index 0')"
+
+def test_parse_error_str_sequence_reader():
+    err = ParseError(SequenceReader("a a", 2), ["b", "c"])
+    assert str(err) == "Expected b or c but found a at index 2"
 
 
-def test_parse_error_equality():
-    error = ParseError("foo")
-    assert error == ParseError("foo")
-    assert error != ParseError("bar")
-    assert error != "foo"
+def test_parse_error_str_sequence_reader_end_of_source():
+    err = ParseError(SequenceReader("a a", 3), ["b"])
+    assert str(err) == "Expected b but found end of source"
+
+
+def test_parse_error_str_string_reader():
+    err = ParseError(StringReader("a a", 2), ["'b'", "'c'"])
+    assert str(err) == "Expected 'b' or 'c' but found 'a'\nLine 1, character 3\n\na a\n  ^"
+
+
+def test_parse_error_str_string_reader_end_of_source():
+    err = ParseError(StringReader("a a", 3), ["'b'"])
+    assert str(err) == "Expected 'b' but found end of source"
 
 
 def test_register_failure_first():
@@ -62,7 +71,7 @@ def test_register_failure_tied():
 
 def test_isinstance():
     success = Success(1)
-    failure = Failure(ParseError("foo"))
+    failure = Failure(ParseError(StringReader("bar baz", 4), ["foo"]))
     assert isinstance(success, Success)
     assert isinstance(failure, Failure)
 
@@ -70,7 +79,7 @@ def test_isinstance():
 @pytest.mark.xfail(reason="Result is a type alias and importing the concrete type would break eager annotations")
 def test_isinstance_result():
     success = Success(1)
-    failure = Failure(ParseError("foo"))
+    failure = Failure(ParseError(StringReader("bar baz", 4), ["foo"]))
     assert isinstance(success, Result)
     assert isinstance(failure, Result)
 


### PR DESCRIPTION
Convert `ParseError` to a dataclass that holds the parsing state. The message is moved to the `__str__` method of the error.

Implements #39.