### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
-name: python
+name: ci
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   python-version: "3.9"


### PR DESCRIPTION
If someone made a PR, then CI would not run under the current workflow settings. This updates the workflow to run on all PRs and also on any pushes to `master`, which is triggered on PR merge.

This also renames the workflow to `ci.yml`, which better reflects the name of this workflow.