### PR TITLE
Enable W on ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ line-length = 120
 src = ["src"]
 line-length = 120
 extend-select = [
+    "W", # pycodestyle
     "I", # isort
     "N", # pep8-naming
     "RUF", # ruff

--- a/src/parsita/parsers/_regex.py
+++ b/src/parsita/parsers/_regex.py
@@ -46,11 +46,9 @@ def reg(pattern: StringType) -> RegexParser[StringType]:
 
     This matches the text with a regular expression. The regular expressions is
     treated as greedy. Backtracking in the parser combinators does not flow into
-    regular expression backtracking. This is only valid in the ``TextParsers``
-    context and not in the ``GeneralParsers`` context because regular
-    expressions only operate on text.
+    regular expression backtracking.
 
     Args:
-        pattern: str or python regular expression.
+        pattern: str, bytes, or python regular expression.
     """
     return RegexParser(pattern, options.whitespace)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -41,8 +41,8 @@ def test_literals():
 
 def test_regex():
     class TestParsers(GeneralParsers):
-        status_code = reg(b"\d+")
-        status = reg(b"[^\n]*")
+        status_code = reg(rb"\d+")
+        status = reg(rb"[^\n]*")
         http_response = status_code << lit(b" ") & status
 
     assert TestParsers.http_response.parse(b"404 Not Found") == Success([b"404", b"Not Found"])


### PR DESCRIPTION
This used to be enabled when we used flake8, but was lost in the migration to Ruff.