### PR TITLE
Activate strict pytest options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,18 @@ ruff = ">=0.0.265"
 mkdocs-material = "^9"
 
 
+[tool.pytest.ini_options]
+addopts = [
+    "--strict-config",
+    "--strict-markers",
+]
+xfail_strict = true
+filterwarnings = [
+    # When running tests, treat warnings as errors (e.g. -Werror).
+    "error",
+]
+
+
 [tool.coverage.run]
 branch = true
 
@@ -62,7 +74,6 @@ line-length = 120
 src = ["src"]
 line-length = 120
 extend-select = [
-    "W", # pycodestyle
     "I", # isort
     "N", # pep8-naming
     "RUF", # ruff


### PR DESCRIPTION
This is a [better solution](https://github.com/johnthagen/python-blueprint/pull/178) than pycodestyle warnings for detecting invalid escape sequences.