### PR TITLE
Remove context-specific lit

### DIFF
--- a/src/parsita/metaclasses.py
+++ b/src/parsita/metaclasses.py
@@ -107,7 +107,7 @@ class GeneralParsersMeta(type):
         for name, forward_declaration in dct.forward_declarations.items():
             obj = dct[name]
             if not isinstance(obj, Parser):
-                obj = LiteralParser(obj)
+                obj = LiteralParser(obj, options.whitespace)
             forward_declaration._definition = obj
 
         # Reset global variables

--- a/src/parsita/metaclasses.py
+++ b/src/parsita/metaclasses.py
@@ -84,7 +84,7 @@ class GeneralParsersMeta(type):
         if whitespace is missing:
             whitespace = mcs.default_whitespace
 
-        if isinstance(whitespace, str):
+        if isinstance(whitespace, (str, bytes)):
             whitespace = re.compile(whitespace)
 
         if isinstance(whitespace, Pattern):

--- a/src/parsita/options.py
+++ b/src/parsita/options.py
@@ -1,7 +1,9 @@
 __all__ = ["whitespace"]
 
+from typing import Any
+
 from .parsers import Parser
 from .state import Input
 
 # Global mutable state
-whitespace: Parser[Input, Input] = None
+whitespace: Parser[Input, Any] = None

--- a/src/parsita/options.py
+++ b/src/parsita/options.py
@@ -1,32 +1,7 @@
-__all__ = [
-    "default_whitespace",
-    "whitespace",
-    "default_handle_literal",
-    "wrap_literal",
-    "handle_literal",
-]
-import re
-from typing import Any, Sequence
+__all__ = ["whitespace"]
 
+from .parsers import Parser
 from .state import Input
 
 # Global mutable state
-
-default_whitespace = re.compile(r"\s*")
-whitespace = None
-
-
-# PyCharm does not understand type hint on handle_literal, so this signature is more general
-def default_handle_literal(literal: Any):
-    from .parsers import LiteralStringParser
-
-    return LiteralStringParser(literal, whitespace)
-
-
-def wrap_literal(literal: Sequence[Input]):
-    from .parsers import LiteralParser
-
-    return LiteralParser(literal)
-
-
-handle_literal = default_handle_literal
+whitespace: Parser[Input, Input] = None

--- a/src/parsita/parsers/__init__.py
+++ b/src/parsita/parsers/__init__.py
@@ -4,7 +4,7 @@ from ._base import Parser
 from ._conversion import ConversionParser, TransformationParser
 from ._debug import DebugParser, debug
 from ._end_of_source import EndOfSourceParser, eof
-from ._literal import LiteralParser, LiteralStringParser, lit
+from ._literal import LiteralParser, lit
 from ._optional import OptionalParser, opt
 from ._predicate import PredicateParser, pred
 from ._regex import RegexParser, reg

--- a/src/parsita/parsers/_base.py
+++ b/src/parsita/parsers/_base.py
@@ -172,10 +172,12 @@ class Parser(Generic[Input, Output]):
 
     @staticmethod
     def handle_other(obj: Any) -> Parser:
+        from ._literal import LiteralParser
+
         if isinstance(obj, Parser):
             return obj
         else:
-            return options.handle_literal(obj)
+            return LiteralParser(obj, options.whitespace)
 
     def __or__(self, other) -> Parser:
         from ._alternative import LongestAlternativeParser

--- a/src/parsita/parsers/_literal.py
+++ b/src/parsita/parsers/_literal.py
@@ -1,6 +1,6 @@
 __all__ = ["LiteralParser", "lit"]
 
-from typing import Optional, Sequence
+from typing import Any, Optional, Sequence
 
 from .. import options
 from ..state import Continue, Input, Reader, State, StringReader
@@ -8,7 +8,7 @@ from ._base import Parser
 
 
 class LiteralParser(Parser[Input, Input]):
-    def __init__(self, pattern: Sequence[Input], whitespace: Optional[Parser[Input, None]] = None):
+    def __init__(self, pattern: Sequence[Input], whitespace: Optional[Parser[Input, Any]] = None):
         super().__init__()
         self.pattern = pattern
         self.whitespace = whitespace

--- a/src/parsita/parsers/_regex.py
+++ b/src/parsita/parsers/_regex.py
@@ -1,7 +1,7 @@
 __all__ = ["RegexParser", "reg"]
 
 import re
-from typing import Generic, Optional, TypeVar, Union
+from typing import Any, Generic, Optional, TypeVar, Union
 
 from .. import options
 from ..state import Continue, Reader, State
@@ -11,7 +11,7 @@ StringType = TypeVar("StringType", str, bytes)
 
 
 class RegexParser(Generic[StringType], Parser[StringType, StringType]):
-    def __init__(self, pattern: re.Pattern, whitespace: Optional[Parser[StringType, None]] = None):
+    def __init__(self, pattern: re.Pattern, whitespace: Optional[Parser[StringType, Any]] = None):
         super().__init__()
         self.pattern = pattern
         self.whitespace = whitespace

--- a/src/parsita/parsers/_regex.py
+++ b/src/parsita/parsers/_regex.py
@@ -1,7 +1,7 @@
 __all__ = ["RegexParser", "reg"]
 
 import re
-from typing import Generic, Optional, TypeVar
+from typing import Generic, Optional, TypeVar, Union
 
 from .. import options
 from ..state import Continue, Reader, State
@@ -11,11 +11,10 @@ StringType = TypeVar("StringType", str, bytes)
 
 
 class RegexParser(Generic[StringType], Parser[StringType, StringType]):
-    # Python lacks type of compiled regex so use str
-    def __init__(self, pattern: StringType, whitespace: Optional[Parser[StringType, None]] = None):
+    def __init__(self, pattern: re.Pattern, whitespace: Optional[Parser[StringType, None]] = None):
         super().__init__()
+        self.pattern = pattern
         self.whitespace = whitespace
-        self.pattern = re.compile(pattern)
 
     def consume(self, state: State[StringType], reader: Reader[StringType]):
         if self.whitespace is not None:
@@ -41,7 +40,7 @@ class RegexParser(Generic[StringType], Parser[StringType, StringType]):
         return self.name_or_nothing() + f"reg(r'{self.pattern.pattern}')"
 
 
-def reg(pattern: StringType) -> RegexParser[StringType]:
+def reg(pattern: Union[re.Pattern, StringType]) -> RegexParser[StringType]:
     """Match with a regular expression.
 
     This matches the text with a regular expression. The regular expressions is
@@ -51,4 +50,4 @@ def reg(pattern: StringType) -> RegexParser[StringType]:
     Args:
         pattern: str, bytes, or python regular expression.
     """
-    return RegexParser(pattern, options.whitespace)
+    return RegexParser(re.compile(pattern), options.whitespace)


### PR DESCRIPTION
* Behavior on lit now independent of context
* LiteralParser and LiteralStringParser have been combined
* lit is specialized to generate nice text error messages on StringReader
* Removed global mutable state for lit
* GeneralParsers now responds to whitespace and TextParsers inherits this behavior
* default_whitespace moved to context class attribute
* reg now takes Pattern or str
* RegexParser now takes Pattern only