### PR TITLE
Mark GeneralParsers and TextParsers as deprecated

### DIFF
--- a/src/parsita/metaclasses.py
+++ b/src/parsita/metaclasses.py
@@ -1,6 +1,7 @@
 import builtins
 import inspect
 import re
+import warnings
 
 from . import options
 from .parsers import Parser, RegexParser
@@ -67,6 +68,10 @@ def fwd() -> ForwardDeclaration:
     return ForwardDeclaration()
 
 
+# The Deprecated package does not work on __init_subclass__
+deprecation_text = "{} is deprecated; use ParserContext instead. -- Deprecated since 1.8.0."
+
+
 class GeneralParsersMeta(type):
     @classmethod
     def __prepare__(mcs, name, bases, **_):  # noqa: N804
@@ -113,6 +118,10 @@ class GeneralParsers(metaclass=GeneralParsersMeta):
     In Parsita 2.0, this context will be removed, use ``ParserContext`` instead.
     """
 
+    def __init_subclass__(cls, **kwargs) -> None:
+        warnings.warn(DeprecationWarning(deprecation_text.format("GeneralParsers")), stacklevel=1)
+        super().__init_subclass__(**kwargs)
+
 
 class TextParsersMeta(GeneralParsersMeta):
     @classmethod
@@ -154,6 +163,10 @@ class TextParsers(metaclass=TextParsersMeta):
 
     In Parsita 2.0, this context will be removed, use ``ParserContext`` instead.
     """
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        warnings.warn(DeprecationWarning(deprecation_text.format("TextParsers")), stacklevel=1)
+        super().__init_subclass__(**kwargs)
 
 
 class ParserContextMeta(TextParsersMeta):

--- a/src/parsita/state.py
+++ b/src/parsita/state.py
@@ -344,7 +344,7 @@ class Failure(Result[NoReturn], result.Failure[ParseError]):
         super().__init__(error)
 
     @property
-    @deprecated("Use failure().message instead.", version="2.0.0")
+    @deprecated("Use failure().message instead.", version="1.8.0")
     def message(self) -> str:
         """A human-readable error message.
 


### PR DESCRIPTION
This is a follow on to #82 to mark the old parser contexts as deprecated.