### PR TITLE
Improve deprecation reporting

### DIFF
--- a/src/parsita/metaclasses.py
+++ b/src/parsita/metaclasses.py
@@ -119,7 +119,7 @@ class GeneralParsers(metaclass=GeneralParsersMeta):
     """
 
     def __init_subclass__(cls, **kwargs) -> None:
-        warnings.warn(DeprecationWarning(deprecation_text.format("GeneralParsers")), stacklevel=1)
+        warnings.warn(DeprecationWarning(deprecation_text.format("GeneralParsers")), stacklevel=2)
         super().__init_subclass__(**kwargs)
 
 
@@ -165,7 +165,7 @@ class TextParsers(metaclass=TextParsersMeta):
     """
 
     def __init_subclass__(cls, **kwargs) -> None:
-        warnings.warn(DeprecationWarning(deprecation_text.format("TextParsers")), stacklevel=1)
+        warnings.warn(DeprecationWarning(deprecation_text.format("TextParsers")), stacklevel=3)
         super().__init_subclass__(**kwargs)
 
 

--- a/src/parsita/state.py
+++ b/src/parsita/state.py
@@ -303,7 +303,7 @@ class Success(Generic[Output], Result[Output], result.Success[Output]):
     """
 
     @property
-    @deprecated("Use unwrap() instead.", version="1.8.0")
+    @deprecated("Use self.unwrap() instead.", version="1.8.0")
     def value(self) -> Output:
         """The value returned from the parser.
 
@@ -311,7 +311,7 @@ class Success(Generic[Output], Result[Output], result.Success[Output]):
         """
         return self.unwrap()
 
-    @deprecated("Use unwrap() instead.", version="1.8.0")
+    @deprecated("Use self.unwrap() instead.", version="1.8.0")
     def or_die(self) -> Output:
         return self.value
 
@@ -342,17 +342,17 @@ class Failure(Result[NoReturn], result.Failure[ParseError]):
         super().__init__(error)
 
     @property
-    @deprecated("Use failure().message instead.", version="1.8.0")
+    @deprecated("Use str(self.failure()) instead.", version="1.8.0")
     def message(self) -> str:
         """A human-readable error message.
 
-        Deprecated: Use self.failure().message instead.
+        Deprecated: Use str(self.failure()) instead.
 
         From the farthest point reached during parsing.
         """
         return self.failure().message
 
-    @deprecated("Use unwrap() instead.", version="1.8.0")
+    @deprecated("Use self.unwrap() instead.", version="1.8.0")
     def or_die(self) -> Output:
         raise self.failure()
 
@@ -363,7 +363,7 @@ class Failure(Result[NoReturn], result.Failure[ParseError]):
             return NotImplemented
 
     def __repr__(self):
-        return f"Failure({self.failure().message!r})"
+        return f"Failure({str(self.failure())!r})"
 
 
 class Status(Generic[Input, Output]):

--- a/src/parsita/state.py
+++ b/src/parsita/state.py
@@ -309,17 +309,15 @@ class Success(Generic[Output], Result[Output], result.Success[Output]):
 
         Deprecated: Use self.unwrap() instead.
         """
-        return self._inner_value
+        return self.unwrap()
 
     @deprecated("Use unwrap() instead.", version="1.8.0")
     def or_die(self) -> Output:
         return self.value
 
     def __eq__(self, other):
-        if isinstance(other, Success):
-            return self.value == other.value
-        elif isinstance(other, result.Success):
-            return self._inner_value == other._inner_value
+        if isinstance(other, result.Success):
+            return self.unwrap() == other.unwrap()
         else:
             return NotImplemented
 
@@ -352,22 +350,20 @@ class Failure(Result[NoReturn], result.Failure[ParseError]):
 
         From the farthest point reached during parsing.
         """
-        return str(self._inner_value)
+        return self.failure().message
 
     @deprecated("Use unwrap() instead.", version="1.8.0")
     def or_die(self) -> Output:
-        raise ParseError(self.message)
+        raise self.failure()
 
     def __eq__(self, other):
-        if isinstance(other, Failure):
-            return self.message == other.message
-        elif isinstance(other, result.Failure):
-            return self._inner_value == other._inner_value
+        if isinstance(other, result.Failure):
+            return self.failure() == other.failure()
         else:
             return NotImplemented
 
     def __repr__(self):
-        return f"Failure({self.message!r})"
+        return f"Failure({self.failure().message!r})"
 
 
 class Status(Generic[Input, Output]):


### PR DESCRIPTION
The stacklevel on the parser contexts were not right and the state was using deprecated attributes internally.