### PR TITLE
Move predicate parser error to end of parsed content

### DIFF
--- a/src/parsita/parsers/_predicate.py
+++ b/src/parsita/parsers/_predicate.py
@@ -14,13 +14,12 @@ class PredicateParser(Generic[Input, Output], Parser[Input, Input]):
         self.description = description
 
     def consume(self, state: State[Input], reader: Reader[Input]):
-        remainder = reader
-        status = self.parser.cached_consume(state, remainder)
+        status = self.parser.cached_consume(state, reader)
         if isinstance(status, Continue):
             if self.predicate(status.value):
                 return status
             else:
-                state.register_failure(self.description, reader)
+                state.register_failure(self.description, status.remainder)
                 return None
         else:
             return status

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -65,7 +65,7 @@ def test_predicate():
     assert TestParsers.a.parse("A") == Success("A")
     assert TestParsers.d.parse("2") == Success("2")
     assert TestParsers.d.parse("23") == Failure(ParseError(StringReader("23", 1), ["end of source"]))
-    assert TestParsers.d.parse("a") == Failure(ParseError(StringReader("a", 0), ["digit"]))
+    assert TestParsers.d.parse("a") == Failure(ParseError(StringReader("a", 1), ["digit"]))
     assert str(TestParsers.a) == "a = pred(any1, letter A)"
 
 

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -83,8 +83,12 @@ def test_pred_static_expression():
 
     assert PredParsers.static_expression.parse("1") == Success(1)
     assert PredParsers.static_expression.parse("f(2,1)") == Success([2, 1])
-    assert PredParsers.static_expression.parse("a") == Failure(ParseError(StringReader("a", 1), ["'('", "static expression"]))
-    assert PredParsers.static_expression.parse("f(a,1)") == Failure(ParseError(StringReader("f(a,1)", 6), ["static expression"]))
+    assert PredParsers.static_expression.parse("a") == Failure(
+        ParseError(StringReader("a", 1), ["'('", "static expression"])
+    )
+    assert PredParsers.static_expression.parse("f(a,1)") == Failure(
+        ParseError(StringReader("f(a,1)", 6), ["static expression"])
+    )
     assert PredParsers.static_expression.parse("f(2,1") == Failure(ParseError(StringReader("f(2,1", 5), ["','", "')'"]))
 
 

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -54,15 +54,38 @@ def test_literal_multiple():
     assert TestParsers.keyword.parse("int") == Success("int")
 
 
-def test_interval():
+def test_pred_interval():
     class TestParsers(ParserContext, whitespace="[ ]*"):
         number = reg(r"\d+") > int
         pair = "[" >> number << "," & number << "]"
         interval = pred(pair, lambda x: x[0] <= x[1], "ordered pair")
 
     assert TestParsers.interval.parse("[1, 2]") == Success([1, 2])
-    assert isinstance(TestParsers.interval.parse("[2, 1]"), Failure)
+    assert TestParsers.interval.parse("[2, 1]") == Failure(ParseError(StringReader("[2, 1]", 6), ["ordered pair"]))
     assert TestParsers.pair.parse("[1,a]") == TestParsers.interval.parse("[1,a]")
+
+
+def test_pred_static_expression():
+    def is_static(expression):
+        if isinstance(expression, str):
+            return False
+        if isinstance(expression, int):
+            return True
+        elif isinstance(expression, list):
+            return all(is_static(e) for e in expression)
+
+    class PredParsers(ParserContext):
+        name = reg(r"[a-zA-Z]+")
+        integer = reg(r"[0-9]+") > int
+        function = name >> "(" >> repsep(expression, ",") << ")"
+        expression = function | name | integer
+        static_expression = pred(expression, is_static, "static expression")
+
+    assert PredParsers.static_expression.parse("1") == Success(1)
+    assert PredParsers.static_expression.parse("f(2,1)") == Success([2, 1])
+    assert PredParsers.static_expression.parse("a") == Failure(ParseError(StringReader("a", 1), ["'('", "static expression"]))
+    assert PredParsers.static_expression.parse("f(a,1)") == Failure(ParseError(StringReader("f(a,1)", 6), ["static expression"]))
+    assert PredParsers.static_expression.parse("f(2,1") == Failure(ParseError(StringReader("f(2,1", 5), ["','", "')'"]))
 
 
 def test_regex():


### PR DESCRIPTION
Fixes #86 by simply moving the error to the end of successfully parsed content.