### PR TITLE
Show error location even at end of source

### DIFF
--- a/src/parsita/state/_reader.py
+++ b/src/parsita/state/_reader.py
@@ -171,22 +171,26 @@ class StringReader(Reader[str]):
 
     def current_line(self):
         characters_consumed = 0
-        for line_index, line in enumerate(StringIO(self.source)):
+        for line_index, line in enumerate(StringIO(self.source)):  # noqa: B007
             if characters_consumed + len(line) > self.position:
                 # The line with the error has been found
                 character_index = self.position - characters_consumed
-
-                # This creates a line like this '        ^                  '
-                pointer = (" " * character_index) + "^" + (" " * (len(line) - character_index - 1))
-
-                # This adds a newline to line in case it is the end of the file
-                if line[-1] != "\n":
-                    line = line + "\n"
-
-                # Add one to indexes to account for 0-indexes
-                return line_index + 1, character_index + 1, line, pointer
+                break
             else:
                 characters_consumed += len(line)
+        else:
+            # The error is at the end of the input
+            character_index = len(line)
+
+        # This creates a line like this '   ^'
+        pointer = " " * character_index + "^"
+
+        # This adds a newline to line in case it is the end of the file
+        if line[-1] != "\n":
+            line = line + "\n"
+
+        # Add one to indexes to account for 0-indexes
+        return line_index + 1, character_index + 1, line, pointer
 
     def expected_error(self, expected: str) -> str:
         """Generate a basic error to include the current state.
@@ -204,14 +208,16 @@ class StringReader(Reader[str]):
         expected_string = " or ".join(expected)
 
         if self.finished:
-            return super().expected_error(expected)
+            next_string = "end of source"
         else:
-            line_index, character_index, line, pointer = self.current_line()
+            next_string = repr(self.next_token())
 
-            return (
-                f"Expected {expected_string} but found {self.next_token()!r}\n"
-                f"Line {line_index}, character {character_index}\n\n{line}{pointer}"
-            )
+        line_index, character_index, line, pointer = self.current_line()
+
+        return (
+            f"Expected {expected_string} but found {next_string}\n"
+            f"Line {line_index}, character {character_index}\n\n{line}{pointer}"
+        )
 
     def recursion_error(self, repeated_parser: str):
         """Generate an error to indicate that infinite recursion was encountered.
@@ -226,12 +232,9 @@ class StringReader(Reader[str]):
         Returns:
             A full error message
         """
-        if self.finished:
-            return super().recursion_error(repeated_parser)
-        else:
-            line_index, character_index, line, pointer = self.current_line()
+        line_index, character_index, line, pointer = self.current_line()
 
-            return (
-                f"Infinite recursion detected in {repeated_parser}; empty string was matched and will be matched "
-                f"forever\nLine {line_index}, character {character_index}\n\n{line}{pointer}"
-            )
+        return (
+            f"Infinite recursion detected in {repeated_parser}; empty string was matched and will be matched "
+            f"forever\nLine {line_index}, character {character_index}\n\n{line}{pointer}"
+        )

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -458,11 +458,11 @@ def test_infinite_recursion_protection():
         assert actual.value == RecursionError(parser, StringReader(text, 12))
         assert str(actual.value) == (
             f"Infinite recursion detected in {parser!r}; "
-            f"empty string was matched and will be matched forever\n"
+            "empty string was matched and will be matched forever\n"
             "Line 1, character 13\n"
             "\n"
             "foo foo foo bar\n"
-            "            ^   "
+            "            ^"
         )
 
     # Recursion happens at end of stream
@@ -473,7 +473,11 @@ def test_infinite_recursion_protection():
         assert actual.value == RecursionError(parser, StringReader(text, 23))
         assert str(actual.value) == (
             f"Infinite recursion detected in {parser!r}; "
-            f"empty string was matched and will be matched forever at end of source"
+            "empty string was matched and will be matched forever\n"
+            "Line 2, character 12\n"
+            "\n"
+            "foo foo foo\n"
+            "           ^"
         )
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -37,9 +37,15 @@ def test_parse_error_str_string_reader():
     assert str(err) == "Expected 'b' or 'c' but found 'a'\nLine 1, character 3\n\na a\n  ^"
 
 
-def test_parse_error_str_string_reader_end_of_source():
-    err = ParseError(StringReader("a a", 3), ["'b'"])
+@pytest.mark.parametrize("source", ["a a", "a a\n"])
+def test_parse_error_str_string_reader_end_of_source(source):
+    err = ParseError(StringReader(source, 4), ["'b'"])
     assert str(err) == "Expected 'b' but found end of source\nLine 1, character 4\n\na a\n   ^"
+
+
+def test_parse_error_str_string_reader_empty():
+    err = ParseError(StringReader("", 0), ["'a'"])
+    assert str(err) == "Expected 'a' but found end of source\nLine 1, character 1\n\n\n^"
 
 
 def test_register_failure_first():

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -39,7 +39,7 @@ def test_parse_error_str_string_reader():
 
 def test_parse_error_str_string_reader_end_of_source():
     err = ParseError(StringReader("a a", 3), ["'b'"])
-    assert str(err) == "Expected 'b' but found end of source"
+    assert str(err) == "Expected 'b' but found end of source\nLine 1, character 4\n\na a\n   ^"
 
 
 def test_register_failure_first():
@@ -92,14 +92,6 @@ def test_result_annotation():
         return Success(1)
 
     assert foo() == Success(1)
-
-
-def test_current_line():
-    # This test only exists to get 100% test coverage without doing a pragma: no cover on the whole current_line
-    # method. Under normal operation, the for loop should never complete because the position is also on some
-    # line. Here, the position has been artificially advanced beyond the length of the input.
-    reader = StringReader("foo", 3)
-    assert reader.current_line() is None
 
 
 def test_reader_with_defective_next_token_regex():


### PR DESCRIPTION
I often wish that the line and error location was visible even when at the end of the source.