### PR TITLE
Make various methods private

### DIFF
--- a/examples/positioned.py
+++ b/examples/positioned.py
@@ -45,9 +45,9 @@ class PositionedParser(Generic[Input, Output], Parser[Input, Output]):
         super().__init__()
         self.parser = parser
 
-    def consume(self, state: State, reader: Reader[Input]):
+    def _consume(self, state: State, reader: Reader[Input]):
         start = reader.position
-        status = self.parser.cached_consume(state, reader)
+        status = self.parser.consume(state, reader)
 
         if isinstance(status, Continue):
             end = status.remainder.position

--- a/src/parsita/parsers/__init__.py
+++ b/src/parsita/parsers/__init__.py
@@ -1,6 +1,6 @@
 from ._alternative import FirstAlternativeParser, LongestAlternativeParser, first, longest
 from ._any import AnyParser, any1
-from ._base import Parser
+from ._base import Parser, wrap_literal
 from ._conversion import ConversionParser, TransformationParser
 from ._debug import DebugParser, debug
 from ._end_of_source import EndOfSourceParser, eof

--- a/src/parsita/parsers/_alternative.py
+++ b/src/parsita/parsers/_alternative.py
@@ -3,8 +3,7 @@ __all__ = ["FirstAlternativeParser", "first", "LongestAlternativeParser", "longe
 from typing import Generic, Optional, Sequence, Union
 
 from ..state import Continue, Input, Output, Reader, State
-from ._base import Parser
-from ._literal import lit
+from ._base import Parser, wrap_literal
 
 
 class FirstAlternativeParser(Generic[Input, Output], Parser[Input, Output]):
@@ -46,9 +45,7 @@ def first(
     Args:
         *parsers: Non-empty list of ``Parser``s or literals to try
     """
-    cleaned_parsers = [
-        lit(parser_i) if isinstance(parser_i, str) else parser_i for parser_i in [parser, *parsers]
-    ]
+    cleaned_parsers = [wrap_literal(parser_i) for parser_i in [parser, *parsers]]
     return FirstAlternativeParser(*cleaned_parsers)
 
 
@@ -97,7 +94,5 @@ def longest(
     Args:
         *parsers: Non-empty list of ``Parser``s or literals to try
     """
-    cleaned_parsers = [
-        lit(parser_i) if isinstance(parser_i, str) else parser_i for parser_i in [parser, *parsers]
-    ]
+    cleaned_parsers = [wrap_literal(parser_i) for parser_i in [parser, *parsers]]
     return LongestAlternativeParser(*cleaned_parsers)

--- a/src/parsita/parsers/_alternative.py
+++ b/src/parsita/parsers/_alternative.py
@@ -11,9 +11,9 @@ class FirstAlternativeParser(Generic[Input, Output], Parser[Input, Output]):
         super().__init__()
         self.parsers = (parser, *parsers)
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
+    def _consume(self, state: State[Input], reader: Reader[Input]):
         for parser in self.parsers:
-            status = parser.cached_consume(state, reader)
+            status = parser.consume(state, reader)
             if isinstance(status, Continue):
                 return status
 
@@ -54,10 +54,10 @@ class LongestAlternativeParser(Generic[Input, Output], Parser[Input, Output]):
         super().__init__()
         self.parsers = (parser, *parsers)
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
+    def _consume(self, state: State[Input], reader: Reader[Input]):
         longest_success: Optional[Continue] = None
         for parser in self.parsers:
-            status = parser.cached_consume(state, reader)
+            status = parser.consume(state, reader)
             if isinstance(status, Continue):
                 if (
                     longest_success is None

--- a/src/parsita/parsers/_any.py
+++ b/src/parsita/parsers/_any.py
@@ -18,7 +18,7 @@ class AnyParser(Generic[Input], Parser[Input, Input]):
     def __init__(self):
         super().__init__()
 
-    def consume(
+    def _consume(
         self, state: State[Input], reader: Reader[Input]
     ) -> Optional[Continue[Input, Input]]:
         if reader.finished:

--- a/src/parsita/parsers/_conversion.py
+++ b/src/parsita/parsers/_conversion.py
@@ -14,10 +14,10 @@ class ConversionParser(Generic[Input, Output, Convert], Parser[Input, Convert]):
         self.parser = parser
         self.converter = converter
 
-    def consume(
+    def _consume(
         self, state: State[Input], reader: Reader[Input]
     ) -> Optional[Continue[Input, Convert]]:
-        status = self.parser.cached_consume(state, reader)
+        status = self.parser.consume(state, reader)
 
         if isinstance(status, Continue):
             return Continue(status.remainder, self.converter(status.value))
@@ -38,12 +38,12 @@ class TransformationParser(Generic[Input, Output, Convert], Parser[Input, Conver
         self.parser = parser
         self.transformer = transformer
 
-    def consume(
+    def _consume(
         self, state: State[Input], reader: Reader[Input]
     ) -> Optional[Continue[Input, Convert]]:
-        status = self.parser.cached_consume(state, reader)
+        status = self.parser.consume(state, reader)
 
         if isinstance(status, Continue):
-            return self.transformer(status.value).cached_consume(state, status.remainder)
+            return self.transformer(status.value).consume(state, status.remainder)
         else:
             return status

--- a/src/parsita/parsers/_debug.py
+++ b/src/parsita/parsers/_debug.py
@@ -19,14 +19,14 @@ class DebugParser(Generic[Input, Output], Parser[Input, Output]):
         self.callback = callback
         self._parser_string = repr(parser)
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
+    def _consume(self, state: State[Input], reader: Reader[Input]):
         if self.verbose:
             print(f"""Evaluating token {reader.next_token()} using parser {self._parser_string}""")
 
         if self.callback:
             self.callback(self.parser, reader)
 
-        result = self.parser.cached_consume(state, reader)
+        result = self.parser.consume(state, reader)
 
         if self.verbose:
             print(f"""Result {result!r}""")

--- a/src/parsita/parsers/_debug.py
+++ b/src/parsita/parsers/_debug.py
@@ -3,8 +3,7 @@ __all__ = ["DebugParser", "debug"]
 from typing import Callable, Generic, Optional
 
 from ..state import Input, Output, Reader, State
-from ._base import Parser
-from ._literal import lit
+from ._base import Parser, wrap_literal
 
 
 class DebugParser(Generic[Input, Output], Parser[Input, Output]):
@@ -62,6 +61,4 @@ def debug(
             invoked. This allows the use to inspect the state of the input or
             add breakpoints before the possibly troublesome parser is invoked.
     """
-    if isinstance(parser, str):
-        parser = lit(parser)
-    return DebugParser(parser, verbose, callback)
+    return DebugParser(wrap_literal(parser), verbose, callback)

--- a/src/parsita/parsers/_end_of_source.py
+++ b/src/parsita/parsers/_end_of_source.py
@@ -10,7 +10,7 @@ class EndOfSourceParser(Generic[Input], Parser[Input, None]):
     def __init__(self):
         super().__init__()
 
-    def consume(
+    def _consume(
         self, state: State[Input], reader: Reader[Input]
     ) -> Optional[Continue[Input, None]]:
         if reader.finished:

--- a/src/parsita/parsers/_literal.py
+++ b/src/parsita/parsers/_literal.py
@@ -13,9 +13,9 @@ class LiteralParser(Parser[Input, Input]):
         self.pattern = pattern
         self.whitespace = whitespace
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
+    def _consume(self, state: State[Input], reader: Reader[Input]):
         if self.whitespace is not None:
-            status = self.whitespace.cached_consume(state, reader)
+            status = self.whitespace.consume(state, reader)
             reader = status.remainder
 
         if isinstance(reader, StringReader):
@@ -36,7 +36,7 @@ class LiteralParser(Parser[Input, Input]):
                     return None
 
         if self.whitespace is not None:
-            status = self.whitespace.cached_consume(state, reader)
+            status = self.whitespace.consume(state, reader)
             reader = status.remainder
 
         return Continue(reader, self.pattern)

--- a/src/parsita/parsers/_optional.py
+++ b/src/parsita/parsers/_optional.py
@@ -3,8 +3,7 @@ __all__ = ["OptionalParser", "opt"]
 from typing import Generic, List, Sequence, Union
 
 from ..state import Continue, Input, Output, Reader, State
-from ._base import Parser
-from ._literal import lit
+from ._base import Parser, wrap_literal
 
 
 class OptionalParser(Generic[Input, Output], Parser[Input, List[Output]]):
@@ -34,6 +33,4 @@ def opt(parser: Union[Parser[Input, Output], Sequence[Input]]) -> OptionalParser
     Args:
         parser: Parser or literal
     """
-    if isinstance(parser, str):
-        parser = lit(parser)
-    return OptionalParser(parser)
+    return OptionalParser(wrap_literal(parser))

--- a/src/parsita/parsers/_optional.py
+++ b/src/parsita/parsers/_optional.py
@@ -11,8 +11,8 @@ class OptionalParser(Generic[Input, Output], Parser[Input, List[Output]]):
         super().__init__()
         self.parser = parser
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
-        status = self.parser.cached_consume(state, reader)
+    def _consume(self, state: State[Input], reader: Reader[Input]):
+        status = self.parser.consume(state, reader)
 
         if isinstance(status, Continue):
             return Continue(status.remainder, [status.value])

--- a/src/parsita/parsers/_predicate.py
+++ b/src/parsita/parsers/_predicate.py
@@ -15,8 +15,8 @@ class PredicateParser(Generic[Input, Output], Parser[Input, Input]):
         self.predicate = predicate
         self.description = description
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
-        status = self.parser.cached_consume(state, reader)
+    def _consume(self, state: State[Input], reader: Reader[Input]):
+        status = self.parser.consume(state, reader)
         if isinstance(status, Continue):
             if self.predicate(status.value):
                 return status

--- a/src/parsita/parsers/_predicate.py
+++ b/src/parsita/parsers/_predicate.py
@@ -3,7 +3,7 @@ __all__ = ["PredicateParser", "pred"]
 from typing import Callable, Generic
 
 from ..state import Continue, Input, Output, Reader, State
-from ._base import Parser
+from ._base import Parser, wrap_literal
 
 
 class PredicateParser(Generic[Input, Output], Parser[Input, Input]):
@@ -36,11 +36,11 @@ def pred(
     """Match ``parser``'s result if it satisfies the predicate.
 
     Args:
-        parser: Provides the result
+        parser: ``Parser`` or literal
         predicate: A predicate for the result to satisfy
         description: Name for the predicate, to use in error reporting
 
     Returns:
         A ``PredicateParser``.
     """
-    return PredicateParser(parser, predicate, description)
+    return PredicateParser(wrap_literal(parser), predicate, description)

--- a/src/parsita/parsers/_regex.py
+++ b/src/parsita/parsers/_regex.py
@@ -16,9 +16,9 @@ class RegexParser(Generic[StringType], Parser[StringType, StringType]):
         self.pattern = pattern
         self.whitespace = whitespace
 
-    def consume(self, state: State[StringType], reader: Reader[StringType]):
+    def _consume(self, state: State[StringType], reader: Reader[StringType]):
         if self.whitespace is not None:
-            status = self.whitespace.cached_consume(state, reader)
+            status = self.whitespace.consume(state, reader)
             reader = status.remainder
 
         match = self.pattern.match(reader.source, reader.position)
@@ -31,7 +31,7 @@ class RegexParser(Generic[StringType], Parser[StringType, StringType]):
             reader = reader.drop(len(value))
 
             if self.whitespace is not None:
-                status = self.whitespace.cached_consume(state, reader)
+                status = self.whitespace.consume(state, reader)
                 reader = status.remainder
 
             return Continue(reader, value)

--- a/src/parsita/parsers/_repeated.py
+++ b/src/parsita/parsers/_repeated.py
@@ -11,8 +11,8 @@ class RepeatedOnceParser(Generic[Input, Output], Parser[Input, Sequence[Output]]
         super().__init__()
         self.parser = parser
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
-        status = self.parser.cached_consume(state, reader)
+    def _consume(self, state: State[Input], reader: Reader[Input]):
+        status = self.parser.consume(state, reader)
 
         if status is None:
             return None
@@ -20,7 +20,7 @@ class RepeatedOnceParser(Generic[Input, Output], Parser[Input, Sequence[Output]]
             output = [status.value]
             remainder = status.remainder
             while True:
-                status = self.parser.cached_consume(state, remainder)
+                status = self.parser.consume(state, remainder)
                 if isinstance(status, Continue):
                     if remainder.position == status.remainder.position:
                         raise RecursionError(self, remainder)
@@ -57,12 +57,12 @@ class RepeatedParser(Generic[Input, Output], Parser[Input, Sequence[Output]]):
         self.min = min
         self.max = max
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
+    def _consume(self, state: State[Input], reader: Reader[Input]):
         output: List[Output] = []
         remainder = reader
 
         while self.max is None or len(output) < self.max:
-            status = self.parser.cached_consume(state, remainder)
+            status = self.parser.consume(state, remainder)
             if isinstance(status, Continue):
                 if remainder.position == status.remainder.position:
                     raise RecursionError(self, remainder)

--- a/src/parsita/parsers/_repeated.py
+++ b/src/parsita/parsers/_repeated.py
@@ -3,8 +3,7 @@ __all__ = ["RepeatedOnceParser", "rep1", "RepeatedParser", "rep"]
 from typing import Generic, List, Optional, Sequence, Union
 
 from ..state import Continue, Input, Output, Reader, RecursionError, State
-from ._base import Parser
-from ._literal import lit
+from ._base import Parser, wrap_literal
 
 
 class RepeatedOnceParser(Generic[Input, Output], Parser[Input, Sequence[Output]]):
@@ -48,9 +47,7 @@ def rep1(
     Args:
         parser: Parser or literal
     """
-    if isinstance(parser, str):
-        parser = lit(parser)
-    return RepeatedOnceParser(parser)
+    return RepeatedOnceParser(wrap_literal(parser))
 
 
 class RepeatedParser(Generic[Input, Output], Parser[Input, Sequence[Output]]):
@@ -103,6 +100,4 @@ def rep(
         max: Nonnegative integer defining the maximum number of entries that
             will be matched or ``None``, meaning that there is no limit
     """
-    if isinstance(parser, str):
-        parser = lit(parser)
-    return RepeatedParser(parser, min=min, max=max)
+    return RepeatedParser(wrap_literal(parser), min=min, max=max)

--- a/src/parsita/parsers/_repeated_seperated.py
+++ b/src/parsita/parsers/_repeated_seperated.py
@@ -21,8 +21,8 @@ class RepeatedSeparatedParser(Generic[Input, Output], Parser[Input, Sequence[Out
         self.min = min
         self.max = max
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
-        status = self.parser.cached_consume(state, reader)
+    def _consume(self, state: State[Input], reader: Reader[Input]):
+        status = self.parser.consume(state, reader)
 
         if not isinstance(status, Continue):
             output = []
@@ -36,9 +36,9 @@ class RepeatedSeparatedParser(Generic[Input, Output], Parser[Input, Sequence[Out
                 # not the remainder from any separator. That is why the parser
                 # starts from the remainder on the status, but remainder is not
                 # updated until after the parser succeeds.
-                status = self.separator.cached_consume(state, remainder)
+                status = self.separator.consume(state, remainder)
                 if isinstance(status, Continue):
-                    status = self.parser.cached_consume(state, status.remainder)
+                    status = self.parser.consume(state, status.remainder)
                     if isinstance(status, Continue):
                         if remainder.position == status.remainder.position:
                             raise RecursionError(self, remainder)
@@ -95,8 +95,8 @@ class RepeatedOnceSeparatedParser(Generic[Input, Output], Parser[Input, Sequence
         self.parser = parser
         self.separator = separator
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
-        status = self.parser.cached_consume(state, reader)
+    def _consume(self, state: State[Input], reader: Reader[Input]):
+        status = self.parser.consume(state, reader)
 
         if status is None:
             return None
@@ -109,9 +109,9 @@ class RepeatedOnceSeparatedParser(Generic[Input, Output], Parser[Input, Sequence
                 # not the remainder from any separator. That is why the parser
                 # starts from the remainder on the status, but remainder is not
                 # updated until after the parser succeeds.
-                status = self.separator.cached_consume(state, remainder)
+                status = self.separator.consume(state, remainder)
                 if isinstance(status, Continue):
-                    status = self.parser.cached_consume(state, status.remainder)
+                    status = self.parser.consume(state, status.remainder)
                     if isinstance(status, Continue):
                         if remainder.position == status.remainder.position:
                             raise RecursionError(self, remainder)

--- a/src/parsita/parsers/_repeated_seperated.py
+++ b/src/parsita/parsers/_repeated_seperated.py
@@ -3,8 +3,7 @@ __all__ = ["RepeatedSeparatedParser", "repsep", "RepeatedOnceSeparatedParser", "
 from typing import Any, Generic, Optional, Sequence, Union
 
 from ..state import Continue, Input, Output, Reader, RecursionError, State
-from ._base import Parser
-from ._literal import lit
+from ._base import Parser, wrap_literal
 
 
 class RepeatedSeparatedParser(Generic[Input, Output], Parser[Input, Sequence[Output]]):
@@ -87,11 +86,7 @@ def repsep(
         max: Nonnegative integer defining the maximum number of entries that
             will be matched or ``None``, meaning that there is no limit
     """
-    if isinstance(parser, str):
-        parser = lit(parser)
-    if isinstance(separator, str):
-        separator = lit(separator)
-    return RepeatedSeparatedParser(parser, separator, min=min, max=max)
+    return RepeatedSeparatedParser(wrap_literal(parser), wrap_literal(separator), min=min, max=max)
 
 
 class RepeatedOnceSeparatedParser(Generic[Input, Output], Parser[Input, Sequence[Output]]):
@@ -148,8 +143,4 @@ def rep1sep(
         parser: Parser or literal
         separator: Parser or literal
     """
-    if isinstance(parser, str):
-        parser = lit(parser)
-    if isinstance(separator, str):
-        separator = lit(separator)
-    return RepeatedOnceSeparatedParser(parser, separator)
+    return RepeatedOnceSeparatedParser(wrap_literal(parser), wrap_literal(separator))

--- a/src/parsita/parsers/_sequential.py
+++ b/src/parsita/parsers/_sequential.py
@@ -12,12 +12,12 @@ class SequentialParser(Generic[Input], Parser[Input, List[Any]]):
         super().__init__()
         self.parsers = (parser, *parsers)
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
+    def _consume(self, state: State[Input], reader: Reader[Input]):
         output = []
         remainder = reader
 
         for parser in self.parsers:
-            status = parser.cached_consume(state, remainder)
+            status = parser.consume(state, remainder)
             if isinstance(status, Continue):
                 output.append(status.value)
                 remainder = status.remainder
@@ -40,10 +40,10 @@ class DiscardLeftParser(Generic[Input, Output], Parser[Input, Output]):
         self.left = left
         self.right = right
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
-        status = self.left.cached_consume(state, reader)
+    def _consume(self, state: State[Input], reader: Reader[Input]):
+        status = self.left.consume(state, reader)
         if isinstance(status, Continue):
-            return self.right.cached_consume(state, status.remainder)
+            return self.right.consume(state, status.remainder)
         else:
             return None
 
@@ -58,10 +58,10 @@ class DiscardRightParser(Generic[Input, Output], Parser[Input, Output]):
         self.left = left
         self.right = right
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
-        status1 = self.left.cached_consume(state, reader)
+    def _consume(self, state: State[Input], reader: Reader[Input]):
+        status1 = self.left.consume(state, reader)
         if isinstance(status1, Continue):
-            status2 = self.right.cached_consume(state, status1.remainder)
+            status2 = self.right.consume(state, status1.remainder)
             if isinstance(status2, Continue):
                 return Continue(status2.remainder, status1.value)
             else:

--- a/src/parsita/parsers/_success.py
+++ b/src/parsita/parsers/_success.py
@@ -11,7 +11,7 @@ class SuccessParser(Generic[Input, Output], Parser[Any, Output]):
         super().__init__()
         self.value = value
 
-    def consume(self, state: State[Input], reader: Reader[Input]) -> Continue[Input, Output]:
+    def _consume(self, state: State[Input], reader: Reader[Input]) -> Continue[Input, Output]:
         return Continue(reader, self.value)
 
     def __repr__(self):
@@ -36,7 +36,7 @@ class FailureParser(Generic[Input], Parser[Input, NoReturn]):
         super().__init__()
         self.expected = expected
 
-    def consume(self, state: State[Input], reader: Reader[Input]) -> None:
+    def _consume(self, state: State[Input], reader: Reader[Input]) -> None:
         state.register_failure(self.expected, reader)
         return None
 

--- a/src/parsita/parsers/_until.py
+++ b/src/parsita/parsers/_until.py
@@ -11,10 +11,10 @@ class UntilParser(Generic[Input], Parser[Input, Input]):
         super().__init__()
         self.parser = parser
 
-    def consume(self, state: State[Input], reader: Reader[Input]):
+    def _consume(self, state: State[Input], reader: Reader[Input]):
         start_position = reader.position
         while True:
-            status = self.parser.cached_consume(state, reader)
+            status = self.parser.consume(state, reader)
 
             if isinstance(status, Continue):
                 break

--- a/src/parsita/parsers/_until.py
+++ b/src/parsita/parsers/_until.py
@@ -3,8 +3,7 @@ __all__ = ["UntilParser", "until"]
 from typing import Any, Generic
 
 from ..state import Continue, Input, Output, Reader, State
-from ._base import Parser
-from ._literal import lit
+from ._base import Parser, wrap_literal
 
 
 class UntilParser(Generic[Input], Parser[Input, Input]):
@@ -39,6 +38,4 @@ def until(parser: Parser[Input, Output]) -> UntilParser:
     Args:
         parser: Parser or literal
     """
-    if isinstance(parser, str):
-        parser = lit(parser)
-    return UntilParser(parser)
+    return UntilParser(wrap_literal(parser))

--- a/src/parsita/state/_reader.py
+++ b/src/parsita/state/_reader.py
@@ -173,7 +173,7 @@ class StringReader(Reader[str]):
         else:
             return self.source[match.start() : match.end()]
 
-    def current_line(self):
+    def _current_line(self):
         # StringIO is not consistent in how it treats empty strings
         # and other strings not ending in newlines. Ensure that the
         # source always ends in a newline.
@@ -223,7 +223,7 @@ class StringReader(Reader[str]):
         else:
             next_string = repr(self.next_token())
 
-        line_index, character_index, line, pointer = self.current_line()
+        line_index, character_index, line, pointer = self._current_line()
 
         return (
             f"Expected {expected_string} but found {next_string}\n"
@@ -243,7 +243,7 @@ class StringReader(Reader[str]):
         Returns:
             A full error message
         """
-        line_index, character_index, line, pointer = self.current_line()
+        line_index, character_index, line, pointer = self._current_line()
 
         return (
             f"Infinite recursion detected in {repeated_parser}; "


### PR DESCRIPTION
Partially implements #95.

- Rename `StringReader.current_line` to `_current_line`
- Extract `handle_other` to global function
  - Rename `handle_other` to `wrap_literal`
  - Use `wrap_literal` in all parsers
    - `PredicateParser` was not wrapping literals at all, now is
    - Most parsers only wrapped `str`, now all wrap non-`Parser`s
- Rename `consume` to `_consume`
- Rename `cached_consume` to `consume`