### PR TITLE
Add official Poetry badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Code coverage][coverage-image]][coverage-link]
 [![Latest PyPI version][pypi-image]][pypi-link]
 [![Supported Python versions][python-versions-image]][python-versions-link]
+[![Poetry](https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json)](https://python-poetry.org/)
 
 > The executable grammar of parsers combinators made available in the executable pseudocode of Python.
 


### PR DESCRIPTION
Poetry now has an official badge. Add it to the README to make its usage more visible to users.

- https://python-poetry.org/blog/announcing-poetry-1.6.0/#official-poetry-badge