### PR TITLE
Create automatic releases from tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,14 @@
-name: ci
+name: CI
 
 on:
   pull_request:
   push:
     branches:
       - master
-    tags:
-      - "v*"
 
 env:
   python-version: "3.9"
-  poetry-version: "1.4.1"
+  poetry-version: "1.6.1"
 
 jobs:
   test:
@@ -20,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Poetry
         run: pipx install poetry==${{ env.poetry-version }}
       - name: Install Python ${{ matrix.python-version }}
@@ -42,7 +40,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Poetry
         run: pipx install poetry==${{ env.poetry-version }}
       - name: Install Python
@@ -66,7 +64,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Poetry
         run: pipx install poetry==${{ env.poetry-version }}
       - name: Install Python
@@ -81,10 +79,10 @@ jobs:
   poetry-check:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - name: Install poetry
+      - uses: actions/checkout@v4
+      - name: Install Poetry
         run: pipx install poetry==${{ env.poetry-version }}
-      - name: Set up Python
+      - name: Install Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,5 +31,3 @@ jobs:
         run: '[[ "v$(poetry version --short)" == "${{ github.ref_name }}" ]]'
       - name: Upload distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-            repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,5 @@ jobs:
         run: '[[ "v$(poetry version --short)" == "${{ github.ref_name }}" ]]'
       - name: Upload distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+            repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  python-version: "3.9"
+  poetry-version: "1.6.1"
+
+jobs:
+  pypi-publish:
+    name: Publish release to PyPI
+    runs-on: ubuntu-22.04
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Poetry
+        run: pipx install poetry==${{ env.poetry-version }}
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.python-version }}
+      - name: Build release with Poetry
+        run: poetry build
+      - name: Check that tag version and Poetry version match
+        run: '[[ "v$(poetry version --short)" == "${{ github.ref_name }}" ]]'
+      - name: Upload distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -77,7 +77,6 @@ poetry run mkdocs gh-deploy
 2. Tag
     1. Tag commit with "vX.Y.Z"
     2. Push tag to GitHub
-        - `release.yml` will automatically build and publish the tag to PyPI
     3. Wait for [build](https://github.com/drhagen/parsita/actions/workflows/release.yml) to finish
     4. Check [PyPI](https://pypi.org/project/parsita/) for good upload
 3. Publish to conda-forge

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,13 +73,13 @@ poetry run mkdocs gh-deploy
     1. Increment version in `pyproject.toml`
     2. Commit with message "Bump version number to X.Y.Z"
     3. Push commit to GitHub
-    4. Check GitHub Actions to ensure all tests pass
+    4. Check [CI](https://github.com/drhagen/parsita/actions/workflows/ci.yml) to ensure all tests pass
 2. Tag
     1. Tag commit with "vX.Y.Z"
     2. Push tag to GitHub
         - `release.yml` will automatically build and publish the tag to PyPI
     3. Wait for [build](https://github.com/drhagen/parsita/actions/workflows/release.yml) to finish
-    3. Check [PyPI](https://pypi.org/project/parsita/) for good upload
+    4. Check [PyPI](https://pypi.org/project/parsita/) for good upload
 3. Publish to conda-forge
     1. Fork [parsita-feedstock](https://github.com/conda-forge/parsita-feedstock)
     2. Create branch with name `vX.Y.Z`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -77,17 +77,10 @@ poetry run mkdocs gh-deploy
 2. Tag
     1. Tag commit with "vX.Y.Z"
     2. Push tag to GitHub
-    3. Check GitHub Actions for tag
-3. Build
-    1. Clear `dist/`
-    2. Run `poetry build`
-    3. Verify that sdist (`.tar.gz`) and bdist (`.whl`) are in `dist/`
-4. Publish to PyPI
-    1. Run `poetry publish -r test`
-    2. Check [PyPI test server](https://test.pypi.org/project/parsita/) for good upload
-    3. Run `poetry publish`
-    4. Check [PyPI](https://pypi.org/project/parsita/) for good upload
-5. Publish to conda-forge
+        - `release.yml` will automatically build and publish the tag to PyPI
+    3. Wait for [build](https://github.com/drhagen/parsita/actions/workflows/release.yml) to finish
+    3. Check [PyPI](https://pypi.org/project/parsita/) for good upload
+3. Publish to conda-forge
     1. Fork [parsita-feedstock](https://github.com/conda-forge/parsita-feedstock)
     2. Create branch with name `vX.Y.Z`
     3. Update `recipe/meta.yaml`
@@ -100,6 +93,6 @@ poetry run mkdocs gh-deploy
     6. Open PR on upstream
     7. Wait for build to succeed
     8. Squash merge PR
-6. Document
+4. Document
     1. Create [GitHub release](https://github.com/drhagen/parsita/releases) with name "Parsita X.Y.Z" and major changes in body
     2. If appropriate, deploy updated docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parsita"
-version = "2.1.1"
+version = "2.1.1.dev1"
 description = "Parser combinator library for Python"
 authors = ["David Hagen <david@drhagen.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parsita"
-version = "2.1.1.dev1"
+version = "2.1.1"
 description = "Parser combinator library for Python"
 authors = ["David Hagen <david@drhagen.com>"]
 license = "MIT"


### PR DESCRIPTION
With 2FA about to be made mandatory on PyPI, this uses the blessed `pypa/gh-action-pypi-publish` GitHub action to publish a new version to PyPI whenever a new tag is pushed.