### PR TITLE
Fix string representations of parsers

### DIFF
--- a/src/parsita/parsers/_conversion.py
+++ b/src/parsita/parsers/_conversion.py
@@ -25,7 +25,7 @@ class ConversionParser(Generic[Input, Output, Convert], Parser[Input, Convert]):
             return None
 
     def __repr__(self):
-        return self.name_or_nothing() + repr(self.parser)
+        return self.name_or_nothing() + f"{self.parser!r} > {self.converter.__name__}"
 
 
 class TransformationParser(Generic[Input, Output, Convert], Parser[Input, Convert]):

--- a/src/parsita/parsers/_conversion.py
+++ b/src/parsita/parsers/_conversion.py
@@ -47,3 +47,7 @@ class TransformationParser(Generic[Input, Output, Convert], Parser[Input, Conver
             return self.transformer(status.value).consume(state, status.remainder)
         else:
             return status
+
+    def __repr__(self) -> str:
+        string = f"{self.parser.name_or_repr()} >= {self.transformer.__name__}"
+        return self.name_or_nothing() + string

--- a/src/parsita/parsers/_regex.py
+++ b/src/parsita/parsers/_regex.py
@@ -36,8 +36,8 @@ class RegexParser(Generic[StringType], Parser[StringType, StringType]):
 
             return Continue(reader, value)
 
-    def __repr__(self):
-        return self.name_or_nothing() + f"reg(r'{self.pattern.pattern}')"
+    def __repr__(self) -> str:
+        return self.name_or_nothing() + f"reg({self.pattern.pattern!r})"
 
 
 def reg(pattern: Union[re.Pattern, StringType]) -> RegexParser[StringType]:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -437,8 +437,8 @@ def test_conversion():
     assert TestParsers.one.parse("1") == Success(1)
     assert TestParsers.twelve.parse("12") == Success(12)
     assert TestParsers.twentyone.parse("21") == Success(21)
-    assert str(TestParsers.twelve) == "twelve = one & two"
-    assert str(TestParsers.twentyone) == "twentyone = two & one"
+    assert str(TestParsers.twelve) == "twelve = one & two > <lambda>"
+    assert str(TestParsers.twentyone) == "twentyone = two & one > make_twentyone"
 
 
 def test_recursion():

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -342,6 +342,7 @@ def test_transformation_as_parameterized_parser():
     assert NumberParsers.number.parse("decimal 5") == Failure(
         ParseError(StringReader("decimal 5", 8), [r"r'[0-9]+\.[0-9]+'"])
     )
+    assert str(NumberParsers.number) == "number = type >= select_parser"
 
 
 def test_transformation_error_propogation():

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -108,7 +108,7 @@ def test_regex():
     assert TestParsers.digits.parse("   100") == Success("100")
     assert TestParsers.digits.parse("100    ") == Success("100")
     assert TestParsers.digits.parse("   100    ") == Success("100")
-    assert str(TestParsers.digits) == r"digits = reg(r'\d+')"
+    assert str(TestParsers.digits) == r"digits = reg('\\d+')"
 
 
 def test_regex_no_whitespace():
@@ -122,7 +122,7 @@ def test_regex_no_whitespace():
     assert TestParsers.digits.parse("100 ") == Failure(
         ParseError(StringReader("100 ", 3), ["end of source"])
     )
-    assert str(TestParsers.digits) == r"digits = reg(r'\d+') > float"
+    assert str(TestParsers.digits) == r"digits = reg('\\d+') > float"
 
 
 def test_regex_custom_whitespace():
@@ -142,7 +142,7 @@ def test_regex_custom_whitespace():
     assert TestParsers.pair.parse("100\n100") == Failure(
         ParseError(StringReader("100\n100", 3), [r"r'\d+'"])
     )
-    assert str(TestParsers.digits) == r"digits = reg(r'\d+') > float"
+    assert str(TestParsers.digits) == r"digits = reg('\\d+') > float"
     assert str(TestParsers.pair) == "pair = digits & digits"
 
 

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -34,7 +34,7 @@ def test_literal():
     assert TestParsers.hundred.parse("   100") == Success(100)
     assert TestParsers.hundred.parse("100    ") == Success(100)
     assert TestParsers.hundred.parse("   100    ") == Success(100)
-    assert str(TestParsers.hundred) == "hundred = '100'"
+    assert str(TestParsers.hundred) == "hundred = '100' > float"
 
 
 def test_literal_no_whitespace():
@@ -48,7 +48,7 @@ def test_literal_no_whitespace():
     assert TestParsers.hundred.parse("100 ") == Failure(
         ParseError(StringReader("100 ", 3), ["end of source"])
     )
-    assert str(TestParsers.hundred) == "hundred = '100'"
+    assert str(TestParsers.hundred) == "hundred = '100' > float"
 
 
 def test_literal_multiple():
@@ -122,7 +122,7 @@ def test_regex_no_whitespace():
     assert TestParsers.digits.parse("100 ") == Failure(
         ParseError(StringReader("100 ", 3), ["end of source"])
     )
-    assert str(TestParsers.digits) == r"digits = reg(r'\d+')"
+    assert str(TestParsers.digits) == r"digits = reg(r'\d+') > float"
 
 
 def test_regex_custom_whitespace():
@@ -142,7 +142,7 @@ def test_regex_custom_whitespace():
     assert TestParsers.pair.parse("100\n100") == Failure(
         ParseError(StringReader("100\n100", 3), [r"r'\d+'"])
     )
-    assert str(TestParsers.digits) == r"digits = reg(r'\d+')"
+    assert str(TestParsers.digits) == r"digits = reg(r'\d+') > float"
     assert str(TestParsers.pair) == "pair = digits & digits"
 
 


### PR DESCRIPTION
The reprs of several parsers were not accurate. This fixes them.

- TransformationParser
- ConversionParser
- RegexParser