### PR TITLE
Handle type annotations

### DIFF
--- a/src/parsita/metaclasses.py
+++ b/src/parsita/metaclasses.py
@@ -32,7 +32,11 @@ class ParsersDict(dict[str, Any]):
         self.forward_declarations: dict[str, ForwardDeclaration[Any, Any]] = {}
 
     @no_type_check  # mypy cannot handle all the frame inspection
-    def __missing__(self, key: str) -> ForwardDeclaration[Any, Any]:
+    def __missing__(self, key: str) -> Any:
+        # Allow type annotations in the class body  
+        if key == "__annotations__":
+            return {}
+
         frame = inspect.currentframe()  # Should be the frame of __missing__
         while frame.f_code.co_name != "__missing__":  # pragma: no cover
             # But sometimes debuggers add frames on top of the stack;

--- a/src/parsita/metaclasses.py
+++ b/src/parsita/metaclasses.py
@@ -33,7 +33,7 @@ class ParsersDict(dict[str, Any]):
 
     @no_type_check  # mypy cannot handle all the frame inspection
     def __missing__(self, key: str) -> Any:
-        # Allow type annotations in the class body  
+        # Allow type annotations in the class body
         if key == "__annotations__":
             return {}
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,6 +3,7 @@ from typing import Union
 import pytest
 
 from parsita import (
+    Parser,
     Failure,
     ParseError,
     ParserContext,
@@ -565,3 +566,9 @@ def test_disallow_instatiation():
 
     with pytest.raises(TypeError):
         _ = TestParsers()
+
+def test_type_annotations():
+    class TestParsers(ParserContext):
+        w: Parser[str, str] = lit("w")
+
+    assert TestParsers.w.parse("w") == Success("w")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,9 +3,9 @@ from typing import Union
 import pytest
 
 from parsita import (
-    Parser,
     Failure,
     ParseError,
+    Parser,
     ParserContext,
     RecursionError,
     SequenceReader,
@@ -566,6 +566,7 @@ def test_disallow_instatiation():
 
     with pytest.raises(TypeError):
         _ = TestParsers()
+
 
 def test_type_annotations():
     class TestParsers(ParserContext):


### PR DESCRIPTION
I've tried adding type annotations to parser and I was getting
```
TypeError: 'ForwardDeclaration' object does not support item assignment
```

This PR fixes it by ignoring annotations, which is likely wrong. I'd be happy to improve the solution.